### PR TITLE
Entity decoding so that HTML entities can be used in L10N file

### DIFF
--- a/src/L10N.js
+++ b/src/L10N.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 
 import stripJsonComments from 'strip-json-comments'
 import Debug from './Debug'
-import { decodedEntities } from './utilities'
+import { decodeEntities } from './utilities'
 
 /**
  * @typedef {Object.<string, string>|string} Localizable
@@ -105,9 +105,9 @@ export default class L10N {
         return data
       } else { // an object is available
         if (this.currentLang_ in data) { // current language available
-          return decodedEntities(data[this.currentLang_])
+          return decodeEntities(data[this.currentLang_])
         } else if (this.defaultLang_ in data) { // default language as a last resort
-          return decodedEntities(data[this.defaultLang_])
+          return decodeEntities(data[this.defaultLang_])
         } else {
           Debug.error('Unable to obtain localization')
         }

--- a/src/L10N.js
+++ b/src/L10N.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 
 import stripJsonComments from 'strip-json-comments'
 import Debug from './Debug'
+import { decodedEntities } from './utilities'
 
 /**
  * @typedef {Object.<string, string>|string} Localizable
@@ -104,9 +105,9 @@ export default class L10N {
         return data
       } else { // an object is available
         if (this.currentLang_ in data) { // current language available
-          return data[this.currentLang_]
+          return decodedEntities(data[this.currentLang_])
         } else if (this.defaultLang_ in data) { // default language as a last resort
-          return data[this.defaultLang_]
+          return decodedEntities(data[this.defaultLang_])
         } else {
           Debug.error('Unable to obtain localization')
         }

--- a/src/MessageDisplay.js
+++ b/src/MessageDisplay.js
@@ -1,6 +1,6 @@
 import 'notifyjs-browser'
 import $ from 'jquery'
-import { decodedEntities } from './utilities'
+import { decodeEntities } from './utilities'
 
 /**
  * @typedef {object} MessageReducedDisplayOptions
@@ -87,7 +87,7 @@ export default class MessageDisplay {
     if (options.hasOwnProperty('className')) { msgOptions.className = options.className }
     if (options.hasOwnProperty('position')) { msgOptions.position = options.position }
 
-    this.$element_.notify(decodedEntities(message), msgOptions)
+    this.$element_.notify(decodeEntities(message), msgOptions)
 
     // HOTFIX for notifyjs issue
     $('.notifyjs-wrapper').click(() => {

--- a/src/MessageDisplay.js
+++ b/src/MessageDisplay.js
@@ -1,5 +1,6 @@
 import 'notifyjs-browser'
 import $ from 'jquery'
+import { decodedEntities } from './utilities'
 
 /**
  * @typedef {object} MessageReducedDisplayOptions
@@ -86,11 +87,7 @@ export default class MessageDisplay {
     if (options.hasOwnProperty('className')) { msgOptions.className = options.className }
     if (options.hasOwnProperty('position')) { msgOptions.position = options.position }
 
-    let temp = document.createElement('p')
-    temp.innerHTML = message
-    let decodedMessage = temp.textContent || temp.innerText
-
-    this.$element_.notify(decodedMessage, msgOptions)
+    this.$element_.notify(decodedEntities(message), msgOptions)
 
     // HOTFIX for notifyjs issue
     $('.notifyjs-wrapper').click(() => {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,6 @@
 /**
  * @module utilities
- * Helper- and Miscfunctions
+ * Helper and misc functions
  */
 
 import $ from 'jquery'
@@ -402,4 +402,17 @@ export function mixin (baseClass, mixinClass) {
   }
 
   return m
+}
+
+/**
+ * Takes a string with HTML entities and replaces the entities by the characters they stand for.
+ * @param stringWithEntities string with encoded HTML entities
+ * @returns {string}
+ */
+export function decodedEntities (stringWithEntities) {
+  let temp = document.createElement('p') // an paragraph element to used for decoding
+  temp.innerHTML = stringWithEntities // the inner HTML be the string with encoded HTML entities
+  let stringWithoutEntities = temp.textContent || temp.innerText // get text content of paragraph element
+  temp = null // discard paragraph element
+  return stringWithoutEntities
 }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -409,7 +409,7 @@ export function mixin (baseClass, mixinClass) {
  * @param stringWithEntities string with encoded HTML entities
  * @returns {string}
  */
-export function decodedEntities (stringWithEntities) {
+export function decodeEntities (stringWithEntities) {
   let temp = document.createElement('p') // an paragraph element to used for decoding
   temp.innerHTML = stringWithEntities // the inner HTML be the string with encoded HTML entities
   let stringWithoutEntities = temp.textContent || temp.innerText // get text content of paragraph element


### PR DESCRIPTION
For some odd reason this decoding had gone missing in action. Restored it.
