### PR TITLE
Reworked tests to wait for elements

### DIFF
--- a/tests/selenium/config.js
+++ b/tests/selenium/config.js
@@ -1,5 +1,5 @@
 ﻿export default {
-  mochaTimeout: 30000,
-  seleniumTimeout: 10000,
+  mochaTimeout: 10000,
+  seleniumTimeout: 5000,
   testClient: 'http://localhost:8080'
 }

--- a/tests/selenium/measurementButton_spec.js
+++ b/tests/selenium/measurementButton_spec.js
@@ -29,7 +29,6 @@ test.describe('measurementButton', function () {
   test.after(function () {
     driver.quit()
   })
-
   // functions //////////////////////////////////////////////////////////////
 
   let checkButtonIsPresent = function (name) {


### PR DESCRIPTION
Letting the tests wait for the elements before checking any properties of them. This seems to increase the successrate of selenium tests,
