### PR TITLE
Reintroduced global createG4U function

### DIFF
--- a/conf/full/entry.js
+++ b/conf/full/entry.js
@@ -1,7 +1,7 @@
 import { createG4U } from '../../src/main'
 
-import clientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
-import layerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
+import defaultClientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
+import defaultLayerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
 
 import 'file?name=files/[name].[ext]!../../files/hotelsbonn.kml'
 import 'file?name=files/[name].[ext]!../../files/restaurantsbonn.kml'
@@ -39,4 +39,6 @@ import 'file?name=images/doc/[name].[ext]!../../images/doc/zoom.png'
 import 'guide4you-builder/mustache-eval-loader?name=proxy/[name].[ext]!guide4you-proxy/proxy.php'
 import 'file?name=proxy/AjaxProxy.[ext]!guide4you-proxy/LICENSE.txt'
 
-createG4U('#g4u-map', clientConf, layerConf)
+window.createG4U = function (target, clientConf = defaultClientConf, layerConf = defaultLayerConf) {
+  return createG4U(target, clientConf, layerConf)
+}

--- a/conf/full/entry.js
+++ b/conf/full/entry.js
@@ -1,4 +1,4 @@
-import { createG4U } from '../../src/main'
+import { createG4UInternal } from '../../src/main'
 
 import defaultClientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
 import defaultLayerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
@@ -40,5 +40,7 @@ import 'guide4you-builder/mustache-eval-loader?name=proxy/[name].[ext]!guide4you
 import 'file?name=proxy/AjaxProxy.[ext]!guide4you-proxy/LICENSE.txt'
 
 window.createG4U = function (target, clientConf = defaultClientConf, layerConf = defaultLayerConf) {
-  return createG4U(target, clientConf, layerConf)
+  return createG4UInternal(target, clientConf, layerConf)
 }
+
+export default window.createG4U

--- a/conf/simple/entry.js
+++ b/conf/simple/entry.js
@@ -1,4 +1,4 @@
-import { createG4U } from '../../src/main'
+import { createG4UInternal } from '../../src/main'
 
 import defaultClientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
 import defaultLayerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
@@ -9,5 +9,7 @@ import 'file?name=files/[name].[ext]!../../files/hotelsbonn.kml'
 import 'file?name=files/[name].[ext]!../../files/restaurantsbonn.kml'
 
 window.createG4U = function (target, clientConf = defaultClientConf, layerConf = defaultLayerConf) {
-  return createG4U(target, clientConf, layerConf)
+  return createG4UInternal(target, clientConf, layerConf)
 }
+
+export default window.createG4U

--- a/conf/simple/entry.js
+++ b/conf/simple/entry.js
@@ -1,11 +1,13 @@
 import { createG4U } from '../../src/main'
 
-import clientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
-import layerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
+import defaultClientConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./client.commented.json'
+import defaultLayerConf from 'guide4you-builder/mustache-eval-loader?name=conf/[name].[ext]!./layers.commented.json'
 
 import 'guide4you-builder/tojson-file-loader?name=files/[name]!../../files/l10n.json.js'
 
 import 'file?name=files/[name].[ext]!../../files/hotelsbonn.kml'
 import 'file?name=files/[name].[ext]!../../files/restaurantsbonn.kml'
 
-createG4U('#g4u-map', clientConf, layerConf)
+window.createG4U = function (target, clientConf = defaultClientConf, layerConf = defaultLayerConf) {
+  return createG4U(target, clientConf, layerConf)
+}

--- a/html/client.html
+++ b/html/client.html
@@ -13,13 +13,6 @@
             padding: 0;
         }
     </style>
-
-    <script>
-        // These variables can be overwritten to use other than default configuration files
-        // window.g4uClientConfPath = ''
-        // window.g4uLayerConfPath = ''
-    </script>
-
 </head>
 
 <body>
@@ -35,5 +28,10 @@
     &nbsp;<br />
     Being a mandatory prerequisite for this page, Javascript needs to be enabled.
 </noscript>
+<script>
+    createG4U('#g4u-map')
+    // To use other than default config files:
+    // createG4U('#g4u-map', 'path/to/clientConfig.json', 'path/to/layerConfig.json')
+</script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guide4you",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A configurable web client for geo-applications. Uses OpenLayers 3. Suitable for mobile devices.",
   "keywords": [
     "map",

--- a/src/main.js
+++ b/src/main.js
@@ -30,8 +30,8 @@ export function createG4U (element, clientConfPath, layerConfPath, modules) {
 
       // for remote analysis and debugging - not used inside of the software
       window.map = new G4UMap(element, clientConfPath, layerConfPath, {
-          modules: modules
-        })
+        modules: modules
+      })
 
       resolve(window.map)
     })

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ import G4UMap from './G4UMap'
 
 import 'polyfill!requestAnimationFrame,cancelAnimationFrame'
 
-export function createG4U (element, clientConfPath, layerConfPath, modules) {
+export function createG4UInternal (element, clientConfPath, layerConfPath, modules) {
   return new Promise((resolve, reject) => {
     $(document).ready(() => {
       if (!ol) {

--- a/src/main.js
+++ b/src/main.js
@@ -29,8 +29,7 @@ export function createG4U (element, clientConfPath, layerConfPath, modules) {
       $(element).empty()
 
       // for remote analysis and debugging - not used inside of the software
-      window.map = new G4UMap(element, window.g4uClientConfPath || clientConfPath,
-        window.g4uLayerConfPath || layerConfPath, {
+      window.map = new G4UMap(element, clientConfPath, layerConfPath, {
           modules: modules
         })
 

--- a/tests/selenium/featuretooltip_spec.js
+++ b/tests/selenium/featuretooltip_spec.js
@@ -71,6 +71,7 @@ test.describe('FeatureTooltip', function () {
     driver = phantomDriver()
     driver.manage().window().setSize(1200, 800)
     driver.manage().timeouts().implicitlyWait(config.seleniumTimeout)
+    driver.manage().timeouts().pageLoadTimeout(config.seleniumTimeout)
   })
 
   test.after(function () {


### PR DESCRIPTION
Had this idea to reintroduce the createG4U function. It uses default values for the config filenames injected by webpack now.

This is cleaner than using global variables in my opinion.

What do you think?
