### PR TITLE
v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guide4you",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A configurable web client for geo-applications. Uses OpenLayers 3. Suitable for mobile devices.",
   "keywords": [
     "map",


### PR DESCRIPTION
use guide4you-builder v1.0.\* in dependent packages instead of v1.0.3
